### PR TITLE
Switching to use codeship fork of fsouza/go-dockertools

### DIFF
--- a/dockerutils.go
+++ b/dockerutils.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/fsouza/go-dockerclient"
+	"github.com/codeship/go-dockerclient"
 )
 
 type DockerEnvironment struct {


### PR DESCRIPTION
Hopefully this will be temporary, once https://github.com/fsouza/go-dockerclient/pull/321 is merged we can roll back
